### PR TITLE
docs: change branch to main in how to

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -13,7 +13,8 @@ local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
 parser_config.cue = {
   install_info = {
     url = "https://github.com/eonpatapon/tree-sitter-cue", -- local path or git repo
-    files = {"src/parser.c", "src/scanner.c"}
+    files = {"src/parser.c", "src/scanner.c"},
+    branch = "main"
   },
   filetype = "cue", -- if filetype does not agrees with parser name
 }


### PR DESCRIPTION
Installation fails because branch defaults to `master`
