### PR TITLE
chore: Update Readme for more accurate nvim-treesitter setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 ## Setup in neovim
 
 ```lua
-treesitter.setup {
-  ensure_installed = {
-    "cue",
-    ...
-  }
-}
-
 local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
 parser_config.cue = {
   install_info = {
@@ -22,6 +15,13 @@ parser_config.cue = {
     branch = "main"
   },
   filetype = "cue", -- if filetype does not agrees with parser name
+}
+
+treesitter.setup {
+  ensure_installed = {
+    "cue",
+    ...
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 ## Setup in neovim
 
 ```lua
+-- This is required to not have cue files marked as `cuesheet`
+vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
+        pattern = {"*.cue"},
+        command = "set filetype=cue",
+})
+
 local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
 parser_config.cue = {
   install_info = {


### PR DESCRIPTION
@eonpatapon Love the parser! Small Readme update to reflect that adding custom parser comes before the `treesitter.config` setup. Else the setup fails with `cue` added as `ensure_installed`