### PR TITLE
Fix identifier parsing

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -18,7 +18,7 @@ const
 	unicodeLetter = /\p{L}/,
 	unicodeDigit = /[0-9]/,
 
-	letter = choice(unicodeLetter),
+	letter = choice(unicodeLetter, '$', '_'),
 
 	newline = '\n',
 	terminator = choice(newline, ','),
@@ -138,8 +138,8 @@ module.exports = grammar({
 
 		identifier: $ => token(seq(
 			optional(choice('_#', '#', '_')),
-			choice(letter, '$'),
-			repeat(choice(letter, unicodeDigit, '$', '_')),
+			letter,
+			repeat(choice(letter, unicodeDigit)),
 		)),
 
 		attribute: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -237,17 +237,16 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "\\p{L}"
-                  }
-                ]
+                "type": "PATTERN",
+                "value": "\\p{L}"
               },
               {
                 "type": "STRING",
                 "value": "$"
+              },
+              {
+                "type": "STRING",
+                "value": "_"
               }
             ]
           },
@@ -262,20 +261,20 @@
                     {
                       "type": "PATTERN",
                       "value": "\\p{L}"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "$"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "_"
                     }
                   ]
                 },
                 {
                   "type": "PATTERN",
                   "value": "[0-9]"
-                },
-                {
-                  "type": "STRING",
-                  "value": "$"
-                },
-                {
-                  "type": "STRING",
-                  "value": "_"
                 }
               ]
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1893,6 +1893,520 @@ static inline bool sym_identifier_character_set_2(int32_t c) {
     ? (c < 2979
       ? (c < 2308
         ? (c < 1369
+          ? (c < 750
+            ? (c < 186
+              ? (c < 'a'
+                ? (c < 'A'
+                  ? c == '$'
+                  : (c <= 'Z' || c == '_'))
+                : (c <= 'z' || (c < 181
+                  ? c == 170
+                  : c <= 181)))
+              : (c <= 186 || (c < 710
+                ? (c < 216
+                  ? (c >= 192 && c <= 214)
+                  : (c <= 246 || (c >= 248 && c <= 705)))
+                : (c <= 721 || (c < 748
+                  ? (c >= 736 && c <= 740)
+                  : c <= 748)))))
+            : (c <= 750 || (c < 908
+              ? (c < 895
+                ? (c < 886
+                  ? (c >= 880 && c <= 884)
+                  : (c <= 887 || (c >= 890 && c <= 893)))
+                : (c <= 895 || (c < 904
+                  ? c == 902
+                  : c <= 906)))
+              : (c <= 908 || (c < 1015
+                ? (c < 931
+                  ? (c >= 910 && c <= 929)
+                  : c <= 1013)
+                : (c <= 1153 || (c < 1329
+                  ? (c >= 1162 && c <= 1327)
+                  : c <= 1366)))))))
+          : (c <= 1369 || (c < 1869
+            ? (c < 1749
+              ? (c < 1568
+                ? (c < 1488
+                  ? (c >= 1376 && c <= 1416)
+                  : (c <= 1514 || (c >= 1519 && c <= 1522)))
+                : (c <= 1610 || (c < 1649
+                  ? (c >= 1646 && c <= 1647)
+                  : c <= 1747)))
+              : (c <= 1749 || (c < 1791
+                ? (c < 1774
+                  ? (c >= 1765 && c <= 1766)
+                  : (c <= 1775 || (c >= 1786 && c <= 1788)))
+                : (c <= 1791 || (c < 1810
+                  ? c == 1808
+                  : c <= 1839)))))
+            : (c <= 1957 || (c < 2084
+              ? (c < 2042
+                ? (c < 1994
+                  ? c == 1969
+                  : (c <= 2026 || (c >= 2036 && c <= 2037)))
+                : (c <= 2042 || (c < 2074
+                  ? (c >= 2048 && c <= 2069)
+                  : c <= 2074)))
+              : (c <= 2084 || (c < 2144
+                ? (c < 2112
+                  ? c == 2088
+                  : c <= 2136)
+                : (c <= 2154 || (c < 2230
+                  ? (c >= 2208 && c <= 2228)
+                  : c <= 2247)))))))))
+        : (c <= 2361 || (c < 2693
+          ? (c < 2527
+            ? (c < 2451
+              ? (c < 2417
+                ? (c < 2384
+                  ? c == 2365
+                  : (c <= 2384 || (c >= 2392 && c <= 2401)))
+                : (c <= 2432 || (c < 2447
+                  ? (c >= 2437 && c <= 2444)
+                  : c <= 2448)))
+              : (c <= 2472 || (c < 2493
+                ? (c < 2482
+                  ? (c >= 2474 && c <= 2480)
+                  : (c <= 2482 || (c >= 2486 && c <= 2489)))
+                : (c <= 2493 || (c < 2524
+                  ? c == 2510
+                  : c <= 2525)))))
+            : (c <= 2529 || (c < 2610
+              ? (c < 2575
+                ? (c < 2556
+                  ? (c >= 2544 && c <= 2545)
+                  : (c <= 2556 || (c >= 2565 && c <= 2570)))
+                : (c <= 2576 || (c < 2602
+                  ? (c >= 2579 && c <= 2600)
+                  : c <= 2608)))
+              : (c <= 2611 || (c < 2649
+                ? (c < 2616
+                  ? (c >= 2613 && c <= 2614)
+                  : c <= 2617)
+                : (c <= 2652 || (c < 2674
+                  ? c == 2654
+                  : c <= 2676)))))))
+          : (c <= 2701 || (c < 2866
+            ? (c < 2768
+              ? (c < 2738
+                ? (c < 2707
+                  ? (c >= 2703 && c <= 2705)
+                  : (c <= 2728 || (c >= 2730 && c <= 2736)))
+                : (c <= 2739 || (c < 2749
+                  ? (c >= 2741 && c <= 2745)
+                  : c <= 2749)))
+              : (c <= 2768 || (c < 2831
+                ? (c < 2809
+                  ? (c >= 2784 && c <= 2785)
+                  : (c <= 2809 || (c >= 2821 && c <= 2828)))
+                : (c <= 2832 || (c < 2858
+                  ? (c >= 2835 && c <= 2856)
+                  : c <= 2864)))))
+            : (c <= 2867 || (c < 2949
+              ? (c < 2911
+                ? (c < 2877
+                  ? (c >= 2869 && c <= 2873)
+                  : (c <= 2877 || (c >= 2908 && c <= 2909)))
+                : (c <= 2913 || (c < 2947
+                  ? c == 2929
+                  : c <= 2947)))
+              : (c <= 2954 || (c < 2969
+                ? (c < 2962
+                  ? (c >= 2958 && c <= 2960)
+                  : c <= 2965)
+                : (c <= 2970 || (c < 2974
+                  ? c == 2972
+                  : c <= 2975)))))))))))
+      : (c <= 2980 || (c < 4176
+        ? (c < 3423
+          ? (c < 3218
+            ? (c < 3114
+              ? (c < 3077
+                ? (c < 2990
+                  ? (c >= 2984 && c <= 2986)
+                  : (c <= 3001 || c == 3024))
+                : (c <= 3084 || (c < 3090
+                  ? (c >= 3086 && c <= 3088)
+                  : c <= 3112)))
+              : (c <= 3129 || (c < 3200
+                ? (c < 3160
+                  ? c == 3133
+                  : (c <= 3162 || (c >= 3168 && c <= 3169)))
+                : (c <= 3200 || (c < 3214
+                  ? (c >= 3205 && c <= 3212)
+                  : c <= 3216)))))
+            : (c <= 3240 || (c < 3332
+              ? (c < 3294
+                ? (c < 3253
+                  ? (c >= 3242 && c <= 3251)
+                  : (c <= 3257 || c == 3261))
+                : (c <= 3294 || (c < 3313
+                  ? (c >= 3296 && c <= 3297)
+                  : c <= 3314)))
+              : (c <= 3340 || (c < 3389
+                ? (c < 3346
+                  ? (c >= 3342 && c <= 3344)
+                  : c <= 3386)
+                : (c <= 3389 || (c < 3412
+                  ? c == 3406
+                  : c <= 3414)))))))
+          : (c <= 3425 || (c < 3749
+            ? (c < 3585
+              ? (c < 3507
+                ? (c < 3461
+                  ? (c >= 3450 && c <= 3455)
+                  : (c <= 3478 || (c >= 3482 && c <= 3505)))
+                : (c <= 3515 || (c < 3520
+                  ? c == 3517
+                  : c <= 3526)))
+              : (c <= 3632 || (c < 3716
+                ? (c < 3648
+                  ? (c >= 3634 && c <= 3635)
+                  : (c <= 3654 || (c >= 3713 && c <= 3714)))
+                : (c <= 3716 || (c < 3724
+                  ? (c >= 3718 && c <= 3722)
+                  : c <= 3747)))))
+            : (c <= 3749 || (c < 3840
+              ? (c < 3776
+                ? (c < 3762
+                  ? (c >= 3751 && c <= 3760)
+                  : (c <= 3763 || c == 3773))
+                : (c <= 3780 || (c < 3804
+                  ? c == 3782
+                  : c <= 3807)))
+              : (c <= 3840 || (c < 3976
+                ? (c < 3913
+                  ? (c >= 3904 && c <= 3911)
+                  : c <= 3948)
+                : (c <= 3980 || (c < 4159
+                  ? (c >= 4096 && c <= 4138)
+                  : c <= 4159)))))))))
+        : (c <= 4181 || (c < 4992
+          ? (c < 4696
+            ? (c < 4256
+              ? (c < 4206
+                ? (c < 4193
+                  ? (c >= 4186 && c <= 4189)
+                  : (c <= 4193 || (c >= 4197 && c <= 4198)))
+                : (c <= 4208 || (c < 4238
+                  ? (c >= 4213 && c <= 4225)
+                  : c <= 4238)))
+              : (c <= 4293 || (c < 4348
+                ? (c < 4301
+                  ? c == 4295
+                  : (c <= 4301 || (c >= 4304 && c <= 4346)))
+                : (c <= 4680 || (c < 4688
+                  ? (c >= 4682 && c <= 4685)
+                  : c <= 4694)))))
+            : (c <= 4696 || (c < 4800
+              ? (c < 4752
+                ? (c < 4704
+                  ? (c >= 4698 && c <= 4701)
+                  : (c <= 4744 || (c >= 4746 && c <= 4749)))
+                : (c <= 4784 || (c < 4792
+                  ? (c >= 4786 && c <= 4789)
+                  : c <= 4798)))
+              : (c <= 4800 || (c < 4824
+                ? (c < 4808
+                  ? (c >= 4802 && c <= 4805)
+                  : c <= 4822)
+                : (c <= 4880 || (c < 4888
+                  ? (c >= 4882 && c <= 4885)
+                  : c <= 4954)))))))
+          : (c <= 5007 || (c < 6016
+            ? (c < 5873
+              ? (c < 5743
+                ? (c < 5112
+                  ? (c >= 5024 && c <= 5109)
+                  : (c <= 5117 || (c >= 5121 && c <= 5740)))
+                : (c <= 5759 || (c < 5792
+                  ? (c >= 5761 && c <= 5786)
+                  : c <= 5866)))
+              : (c <= 5880 || (c < 5952
+                ? (c < 5902
+                  ? (c >= 5888 && c <= 5900)
+                  : (c <= 5905 || (c >= 5920 && c <= 5937)))
+                : (c <= 5969 || (c < 5998
+                  ? (c >= 5984 && c <= 5996)
+                  : c <= 6000)))))
+            : (c <= 6067 || (c < 6320
+              ? (c < 6272
+                ? (c < 6108
+                  ? c == 6103
+                  : (c <= 6108 || (c >= 6176 && c <= 6264)))
+                : (c <= 6276 || (c < 6314
+                  ? (c >= 6279 && c <= 6312)
+                  : c <= 6314)))
+              : (c <= 6389 || (c < 6512
+                ? (c < 6480
+                  ? (c >= 6400 && c <= 6430)
+                  : c <= 6509)
+                : (c <= 6516 || (c < 6576
+                  ? (c >= 6528 && c <= 6571)
+                  : c <= 6601)))))))))))))
+    : (c <= 6678 || (c < 43250
+      ? (c < 8579
+        ? (c < 8031
+          ? (c < 7401
+            ? (c < 7098
+              ? (c < 6981
+                ? (c < 6823
+                  ? (c >= 6688 && c <= 6740)
+                  : (c <= 6823 || (c >= 6917 && c <= 6963)))
+                : (c <= 6987 || (c < 7086
+                  ? (c >= 7043 && c <= 7072)
+                  : c <= 7087)))
+              : (c <= 7141 || (c < 7296
+                ? (c < 7245
+                  ? (c >= 7168 && c <= 7203)
+                  : (c <= 7247 || (c >= 7258 && c <= 7293)))
+                : (c <= 7304 || (c < 7357
+                  ? (c >= 7312 && c <= 7354)
+                  : c <= 7359)))))
+            : (c <= 7404 || (c < 7968
+              ? (c < 7424
+                ? (c < 7413
+                  ? (c >= 7406 && c <= 7411)
+                  : (c <= 7414 || c == 7418))
+                : (c <= 7615 || (c < 7960
+                  ? (c >= 7680 && c <= 7957)
+                  : c <= 7965)))
+              : (c <= 8005 || (c < 8025
+                ? (c < 8016
+                  ? (c >= 8008 && c <= 8013)
+                  : c <= 8023)
+                : (c <= 8025 || (c < 8029
+                  ? c == 8027
+                  : c <= 8029)))))))
+          : (c <= 8061 || (c < 8450
+            ? (c < 8150
+              ? (c < 8130
+                ? (c < 8118
+                  ? (c >= 8064 && c <= 8116)
+                  : (c <= 8124 || c == 8126))
+                : (c <= 8132 || (c < 8144
+                  ? (c >= 8134 && c <= 8140)
+                  : c <= 8147)))
+              : (c <= 8155 || (c < 8305
+                ? (c < 8178
+                  ? (c >= 8160 && c <= 8172)
+                  : (c <= 8180 || (c >= 8182 && c <= 8188)))
+                : (c <= 8305 || (c < 8336
+                  ? c == 8319
+                  : c <= 8348)))))
+            : (c <= 8450 || (c < 8488
+              ? (c < 8473
+                ? (c < 8458
+                  ? c == 8455
+                  : (c <= 8467 || c == 8469))
+                : (c <= 8477 || (c < 8486
+                  ? c == 8484
+                  : c <= 8486)))
+              : (c <= 8488 || (c < 8508
+                ? (c < 8495
+                  ? (c >= 8490 && c <= 8493)
+                  : c <= 8505)
+                : (c <= 8511 || (c < 8526
+                  ? (c >= 8517 && c <= 8521)
+                  : c <= 8526)))))))))
+        : (c <= 8580 || (c < 12540
+          ? (c < 11696
+            ? (c < 11559
+              ? (c < 11499
+                ? (c < 11312
+                  ? (c >= 11264 && c <= 11310)
+                  : (c <= 11358 || (c >= 11360 && c <= 11492)))
+                : (c <= 11502 || (c < 11520
+                  ? (c >= 11506 && c <= 11507)
+                  : c <= 11557)))
+              : (c <= 11559 || (c < 11648
+                ? (c < 11568
+                  ? c == 11565
+                  : (c <= 11623 || c == 11631))
+                : (c <= 11670 || (c < 11688
+                  ? (c >= 11680 && c <= 11686)
+                  : c <= 11694)))))
+            : (c <= 11702 || (c < 12293
+              ? (c < 11728
+                ? (c < 11712
+                  ? (c >= 11704 && c <= 11710)
+                  : (c <= 11718 || (c >= 11720 && c <= 11726)))
+                : (c <= 11734 || (c < 11823
+                  ? (c >= 11736 && c <= 11742)
+                  : c <= 11823)))
+              : (c <= 12294 || (c < 12353
+                ? (c < 12347
+                  ? (c >= 12337 && c <= 12341)
+                  : c <= 12348)
+                : (c <= 12438 || (c < 12449
+                  ? (c >= 12445 && c <= 12447)
+                  : c <= 12538)))))))
+          : (c <= 12543 || (c < 42560
+            ? (c < 19968
+              ? (c < 12784
+                ? (c < 12593
+                  ? (c >= 12549 && c <= 12591)
+                  : (c <= 12686 || (c >= 12704 && c <= 12735)))
+                : (c <= 12799 || (c < 19903
+                  ? c == 13312
+                  : c <= 19903)))
+              : (c <= 19968 || (c < 42240
+                ? (c < 40960
+                  ? c == 40956
+                  : (c <= 42124 || (c >= 42192 && c <= 42237)))
+                : (c <= 42508 || (c < 42538
+                  ? (c >= 42512 && c <= 42527)
+                  : c <= 42539)))))
+            : (c <= 42606 || (c < 42997
+              ? (c < 42786
+                ? (c < 42656
+                  ? (c >= 42623 && c <= 42653)
+                  : (c <= 42725 || (c >= 42775 && c <= 42783)))
+                : (c <= 42888 || (c < 42946
+                  ? (c >= 42891 && c <= 42943)
+                  : c <= 42954)))
+              : (c <= 43009 || (c < 43020
+                ? (c < 43015
+                  ? (c >= 43011 && c <= 43013)
+                  : c <= 43018)
+                : (c <= 43042 || (c < 43138
+                  ? (c >= 43072 && c <= 43123)
+                  : c <= 43187)))))))))))
+      : (c <= 43255 || (c < 65142
+        ? (c < 43793
+          ? (c < 43616
+            ? (c < 43471
+              ? (c < 43312
+                ? (c < 43261
+                  ? c == 43259
+                  : (c <= 43262 || (c >= 43274 && c <= 43301)))
+                : (c <= 43334 || (c < 43396
+                  ? (c >= 43360 && c <= 43388)
+                  : c <= 43442)))
+              : (c <= 43471 || (c < 43520
+                ? (c < 43494
+                  ? (c >= 43488 && c <= 43492)
+                  : (c <= 43503 || (c >= 43514 && c <= 43518)))
+                : (c <= 43560 || (c < 43588
+                  ? (c >= 43584 && c <= 43586)
+                  : c <= 43595)))))
+            : (c <= 43638 || (c < 43714
+              ? (c < 43701
+                ? (c < 43646
+                  ? c == 43642
+                  : (c <= 43695 || c == 43697))
+                : (c <= 43702 || (c < 43712
+                  ? (c >= 43705 && c <= 43709)
+                  : c <= 43712)))
+              : (c <= 43714 || (c < 43762
+                ? (c < 43744
+                  ? (c >= 43739 && c <= 43741)
+                  : c <= 43754)
+                : (c <= 43764 || (c < 43785
+                  ? (c >= 43777 && c <= 43782)
+                  : c <= 43790)))))))
+          : (c <= 43798 || (c < 64285
+            ? (c < 55203
+              ? (c < 43868
+                ? (c < 43816
+                  ? (c >= 43808 && c <= 43814)
+                  : (c <= 43822 || (c >= 43824 && c <= 43866)))
+                : (c <= 43881 || (c < 44032
+                  ? (c >= 43888 && c <= 44002)
+                  : c <= 44032)))
+              : (c <= 55203 || (c < 64112
+                ? (c < 55243
+                  ? (c >= 55216 && c <= 55238)
+                  : (c <= 55291 || (c >= 63744 && c <= 64109)))
+                : (c <= 64217 || (c < 64275
+                  ? (c >= 64256 && c <= 64262)
+                  : c <= 64279)))))
+            : (c <= 64285 || (c < 64326
+              ? (c < 64318
+                ? (c < 64298
+                  ? (c >= 64287 && c <= 64296)
+                  : (c <= 64310 || (c >= 64312 && c <= 64316)))
+                : (c <= 64318 || (c < 64323
+                  ? (c >= 64320 && c <= 64321)
+                  : c <= 64324)))
+              : (c <= 64433 || (c < 64914
+                ? (c < 64848
+                  ? (c >= 64467 && c <= 64829)
+                  : c <= 64911)
+                : (c <= 64967 || (c < 65136
+                  ? (c >= 65008 && c <= 65019)
+                  : c <= 65140)))))))))
+        : (c <= 65276 || (c < 66816
+          ? (c < 65664
+            ? (c < 65498
+              ? (c < 65474
+                ? (c < 65345
+                  ? (c >= 65313 && c <= 65338)
+                  : (c <= 65370 || (c >= 65382 && c <= 65470)))
+                : (c <= 65479 || (c < 65490
+                  ? (c >= 65482 && c <= 65487)
+                  : c <= 65495)))
+              : (c <= 65500 || (c < 65596
+                ? (c < 65549
+                  ? (c >= 65536 && c <= 65547)
+                  : (c <= 65574 || (c >= 65576 && c <= 65594)))
+                : (c <= 65597 || (c < 65616
+                  ? (c >= 65599 && c <= 65613)
+                  : c <= 65629)))))
+            : (c <= 65786 || (c < 66432
+              ? (c < 66349
+                ? (c < 66208
+                  ? (c >= 66176 && c <= 66204)
+                  : (c <= 66256 || (c >= 66304 && c <= 66335)))
+                : (c <= 66368 || (c < 66384
+                  ? (c >= 66370 && c <= 66377)
+                  : c <= 66421)))
+              : (c <= 66461 || (c < 66560
+                ? (c < 66504
+                  ? (c >= 66464 && c <= 66499)
+                  : c <= 66511)
+                : (c <= 66717 || (c < 66776
+                  ? (c >= 66736 && c <= 66771)
+                  : c <= 66811)))))))
+          : (c <= 66855 || (c < 67828
+            ? (c < 67594
+              ? (c < 67424
+                ? (c < 67072
+                  ? (c >= 66864 && c <= 66915)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))
+                : (c <= 67431 || (c < 67592
+                  ? (c >= 67584 && c <= 67589)
+                  : c <= 67592)))
+              : (c <= 67637 || (c < 67680
+                ? (c < 67644
+                  ? (c >= 67639 && c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))
+                : (c <= 67702 || (c < 67808
+                  ? (c >= 67712 && c <= 67742)
+                  : c <= 67826)))))
+            : (c <= 67829 || (c < 68117
+              ? (c < 68030
+                ? (c < 67872
+                  ? (c >= 67840 && c <= 67861)
+                  : (c <= 67897 || (c >= 67968 && c <= 68023)))
+                : (c <= 68031 || (c < 68112
+                  ? c == 68096
+                  : c <= 68115)))
+              : (c <= 68119 || (c < 68224
+                ? (c < 68192
+                  ? (c >= 68121 && c <= 68149)
+                  : c <= 68220)
+                : (c <= 68252 || (c < 68297
+                  ? (c >= 68288 && c <= 68295)
+                  : c <= 68309)))))))))))))));
+}
+
+static inline bool sym_identifier_character_set_3(int32_t c) {
+  return (c < 6656
+    ? (c < 2979
+      ? (c < 2308
+        ? (c < 1369
           ? (c < 748
             ? (c < 181
               ? (c < '_'
@@ -2446,7 +2960,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[') ADVANCE(159);
       if (lookahead == '\\') ADVANCE(49);
       if (lookahead == ']') ADVANCE(134);
-      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '_') ADVANCE(82);
       if (lookahead == '{') ADVANCE(135);
       if (lookahead == '|') ADVANCE(142);
       if (lookahead == '}') ADVANCE(136);
@@ -2479,7 +2993,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '?') ADVANCE(138);
       if (lookahead == '@') ADVANCE(85);
       if (lookahead == '[') ADVANCE(159);
-      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '_') ADVANCE(82);
       if (lookahead == '{') ADVANCE(135);
       if (lookahead == '|') ADVANCE(142);
       if (lookahead == '}') ADVANCE(136);
@@ -2511,7 +3025,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '?') ADVANCE(138);
       if (lookahead == '@') ADVANCE(85);
       if (lookahead == '[') ADVANCE(133);
-      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '_') ADVANCE(82);
       if (lookahead == '{') ADVANCE(135);
       if (lookahead == '|') ADVANCE(142);
       if (lookahead == '}') ADVANCE(136);
@@ -2533,7 +3047,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '+') ADVANCE(154);
       if (lookahead == ',') ADVANCE(77);
       if (lookahead == '-') ADVANCE(155);
-      if (lookahead == '.') ADVANCE(29);
+      if (lookahead == '.') ADVANCE(28);
       if (lookahead == '/') ADVANCE(157);
       if (lookahead == '0') ADVANCE(118);
       if (lookahead == '<') ADVANCE(148);
@@ -2541,7 +3055,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '>') ADVANCE(150);
       if (lookahead == '@') ADVANCE(85);
       if (lookahead == '[') ADVANCE(133);
-      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '_') ADVANCE(82);
       if (lookahead == '{') ADVANCE(135);
       if (lookahead == '|') ADVANCE(142);
       if (lookahead == '}') ADVANCE(136);
@@ -2551,7 +3065,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('1' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 4:
-      if (lookahead == '\n') SKIP(23)
+      if (lookahead == '\n') SKIP(22)
       if (lookahead == '\'') ADVANCE(101);
       if (lookahead == '/') ADVANCE(104);
       if (lookahead == '\\') ADVANCE(50);
@@ -2571,18 +3085,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(98);
       END_STATE();
     case 6:
+      if (lookahead == '!') ADVANCE(36);
       if (lookahead == '"') ADVANCE(95);
       if (lookahead == '#') ADVANCE(7);
       if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
+      if (lookahead == '&') ADVANCE(143);
       if (lookahead == '\'') ADVANCE(102);
       if (lookahead == '(') ADVANCE(78);
       if (lookahead == ')') ADVANCE(79);
+      if (lookahead == '*') ADVANCE(156);
+      if (lookahead == '+') ADVANCE(154);
+      if (lookahead == ',') ADVANCE(77);
+      if (lookahead == '-') ADVANCE(155);
       if (lookahead == '.') ADVANCE(80);
-      if (lookahead == '/') ADVANCE(35);
-      if (lookahead == ':') ADVANCE(141);
-      if (lookahead == '=') ADVANCE(139);
-      if (lookahead == '?') ADVANCE(138);
-      if (lookahead == '_') ADVANCE(82);
+      if (lookahead == '/') ADVANCE(157);
+      if (lookahead == '<') ADVANCE(148);
+      if (lookahead == '=') ADVANCE(37);
+      if (lookahead == '>') ADVANCE(150);
+      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '{') ADVANCE(135);
+      if (lookahead == '|') ADVANCE(142);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -2590,7 +3112,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 7:
       if (lookahead == '"') ADVANCE(99);
-      if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
+      if (sym_identifier_character_set_2(lookahead)) ADVANCE(84);
       if (lookahead == '\'') ADVANCE(106);
       END_STATE();
     case 8:
@@ -2603,11 +3125,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '"') ADVANCE(94);
       if (lookahead == '#') ADVANCE(72);
       if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
-      if (lookahead == '\'') ADVANCE(18);
-      if (lookahead == '/') ADVANCE(35);
+      if (lookahead == '\'') ADVANCE(17);
+      if (lookahead == '/') ADVANCE(34);
+      if (lookahead == ':') ADVANCE(141);
+      if (lookahead == '=') ADVANCE(139);
+      if (lookahead == '?') ADVANCE(138);
       if (lookahead == '[') ADVANCE(133);
-      if (lookahead == '\\') ADVANCE(16);
-      if (lookahead == '_') ADVANCE(15);
+      if (lookahead == '\\') ADVANCE(15);
+      if (lookahead == '_') ADVANCE(83);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -2615,8 +3140,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 11:
       if (lookahead == '"') ADVANCE(94);
-      if (lookahead == '/') ADVANCE(35);
-      if (lookahead == '\\') ADVANCE(25);
+      if (lookahead == '/') ADVANCE(34);
+      if (lookahead == '\\') ADVANCE(24);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -2624,8 +3149,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 12:
       if (lookahead == '"') ADVANCE(13);
-      if (lookahead == '/') ADVANCE(35);
-      if (lookahead == '\\') ADVANCE(16);
+      if (lookahead == '/') ADVANCE(34);
+      if (lookahead == '\\') ADVANCE(15);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
@@ -2636,61 +3161,57 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '#') ADVANCE(100);
       END_STATE();
     case 14:
-      if (lookahead == '"') ADVANCE(20);
+      if (lookahead == '"') ADVANCE(19);
       END_STATE();
     case 15:
-      if (lookahead == '#') ADVANCE(72);
-      if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
+      if (lookahead == '#') ADVANCE(25);
       END_STATE();
     case 16:
-      if (lookahead == '#') ADVANCE(26);
-      END_STATE();
-    case 17:
-      if (lookahead == '#') ADVANCE(26);
+      if (lookahead == '#') ADVANCE(25);
       if (lookahead == '(') ADVANCE(114);
       END_STATE();
-    case 18:
+    case 17:
       if (lookahead == '#') ADVANCE(107);
-      if (lookahead == '\'') ADVANCE(24);
+      if (lookahead == '\'') ADVANCE(23);
       END_STATE();
-    case 19:
+    case 18:
       if (lookahead == '#') ADVANCE(113);
       END_STATE();
-    case 20:
+    case 19:
       if (lookahead == '#') ADVANCE(110);
       END_STATE();
-    case 21:
+    case 20:
       if (lookahead == '\'') ADVANCE(111);
       END_STATE();
-    case 22:
+    case 21:
       if (lookahead == '\'') ADVANCE(112);
       END_STATE();
-    case 23:
+    case 22:
       if (lookahead == '\'') ADVANCE(101);
-      if (lookahead == '/') ADVANCE(35);
-      if (lookahead == '\\') ADVANCE(25);
+      if (lookahead == '/') ADVANCE(34);
+      if (lookahead == '\\') ADVANCE(24);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(23)
+          lookahead == ' ') SKIP(22)
+      END_STATE();
+    case 23:
+      if (lookahead == '\'') ADVANCE(18);
       END_STATE();
     case 24:
-      if (lookahead == '\'') ADVANCE(19);
-      END_STATE();
-    case 25:
       if (lookahead == '(') ADVANCE(114);
       END_STATE();
-    case 26:
+    case 25:
       if (lookahead == '(') ADVANCE(115);
       END_STATE();
-    case 27:
+    case 26:
       if (lookahead == '(') ADVANCE(115);
       if (lookahead == 'U') ADVANCE(71);
       if (lookahead == 'u') ADVANCE(67);
       if (lookahead == 'x') ADVANCE(64);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(56);
       END_STATE();
-    case 28:
+    case 27:
       if (lookahead == ')') ADVANCE(79);
       if (lookahead == '/') ADVANCE(88);
       if (lookahead == '\t' ||
@@ -2704,52 +3225,56 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '{' &&
           lookahead != '}') ADVANCE(89);
       END_STATE();
-    case 29:
-      if (lookahead == '.') ADVANCE(30);
+    case 28:
+      if (lookahead == '.') ADVANCE(29);
       if (lookahead == '0') ADVANCE(130);
       if (('1' <= lookahead && lookahead <= '9')) ADVANCE(131);
       END_STATE();
-    case 30:
+    case 29:
       if (lookahead == '.') ADVANCE(137);
       END_STATE();
-    case 31:
+    case 30:
       if (lookahead == '.') ADVANCE(132);
       if (lookahead == 'E' ||
           lookahead == 'e') ADVANCE(43);
       if (lookahead == '_') ADVANCE(53);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(30);
       END_STATE();
-    case 32:
-      if (lookahead == '.') ADVANCE(36);
+    case 31:
+      if (lookahead == '.') ADVANCE(35);
       if (lookahead == 'G' ||
           lookahead == 'K' ||
           lookahead == 'M' ||
           lookahead == 'P' ||
           lookahead == 'T') ADVANCE(124);
       END_STATE();
-    case 33:
-      if (lookahead == '.') ADVANCE(36);
+    case 32:
+      if (lookahead == '.') ADVANCE(35);
       if (lookahead == 'G' ||
           lookahead == 'K' ||
           lookahead == 'M' ||
           lookahead == 'P' ||
           lookahead == 'T') ADVANCE(124);
       if (lookahead == '_') ADVANCE(57);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(33);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
       END_STATE();
-    case 34:
+    case 33:
       if (lookahead == '.') ADVANCE(61);
       if (lookahead == '_') ADVANCE(60);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(121);
       END_STATE();
-    case 35:
+    case 34:
       if (lookahead == '/') ADVANCE(160);
       END_STATE();
+    case 35:
+      if (lookahead == '0') ADVANCE(31);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(32);
+      END_STATE();
     case 36:
-      if (lookahead == '0') ADVANCE(32);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(33);
+      if (lookahead == '=') ADVANCE(147);
+      if (lookahead == '~') ADVANCE(153);
       END_STATE();
     case 37:
       if (lookahead == '=') ADVANCE(146);
@@ -2803,7 +3328,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 47:
       if (lookahead == '8' ||
-          lookahead == '9') ADVANCE(31);
+          lookahead == '9') ADVANCE(30);
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(120);
       END_STATE();
     case 48:
@@ -2811,7 +3336,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 49:
       if (sym_escape_char_character_set_1(lookahead)) ADVANCE(90);
-      if (lookahead == '#') ADVANCE(27);
+      if (lookahead == '#') ADVANCE(26);
       if (lookahead == '(') ADVANCE(114);
       if (lookahead == 'U') ADVANCE(71);
       if (lookahead == 'u') ADVANCE(67);
@@ -2838,7 +3363,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(119);
       END_STATE();
     case 53:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(30);
       END_STATE();
     case 54:
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(129);
@@ -2850,7 +3375,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(92);
       END_STATE();
     case 57:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(33);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
       END_STATE();
     case 58:
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(131);
@@ -2919,7 +3444,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(70);
       END_STATE();
     case 72:
-      if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
+      if (sym_identifier_character_set_2(lookahead)) ADVANCE(84);
       END_STATE();
     case 73:
       if (eof) ADVANCE(75);
@@ -2945,9 +3470,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '?') ADVANCE(138);
       if (lookahead == '@') ADVANCE(85);
       if (lookahead == '[') ADVANCE(133);
-      if (lookahead == '\\') ADVANCE(17);
+      if (lookahead == '\\') ADVANCE(16);
       if (lookahead == ']') ADVANCE(134);
-      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '_') ADVANCE(82);
       if (lookahead == '{') ADVANCE(135);
       if (lookahead == '|') ADVANCE(142);
       if (lookahead == '}') ADVANCE(136);
@@ -2971,7 +3496,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '+') ADVANCE(154);
       if (lookahead == ',') ADVANCE(77);
       if (lookahead == '-') ADVANCE(155);
-      if (lookahead == '.') ADVANCE(29);
+      if (lookahead == '.') ADVANCE(28);
       if (lookahead == '/') ADVANCE(157);
       if (lookahead == '0') ADVANCE(118);
       if (lookahead == '<') ADVANCE(148);
@@ -2980,7 +3505,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '@') ADVANCE(85);
       if (lookahead == '[') ADVANCE(133);
       if (lookahead == ']') ADVANCE(134);
-      if (lookahead == '_') ADVANCE(83);
+      if (lookahead == '_') ADVANCE(82);
       if (lookahead == '{') ADVANCE(135);
       if (lookahead == '|') ADVANCE(142);
       if (lookahead == '}') ADVANCE(136);
@@ -3011,24 +3536,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 81:
       ACCEPT_TOKEN(sym_dot);
-      if (lookahead == '.') ADVANCE(30);
+      if (lookahead == '.') ADVANCE(29);
       if (lookahead == '0') ADVANCE(130);
       if (('1' <= lookahead && lookahead <= '9')) ADVANCE(131);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(anon_sym__);
+      ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '#') ADVANCE(72);
-      if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
+      if (sym_identifier_character_set_2(lookahead)) ADVANCE(84);
+      if (lookahead == '|') ADVANCE(42);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(84);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(anon_sym__);
+      ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '#') ADVANCE(72);
-      if (sym_identifier_character_set_1(lookahead)) ADVANCE(84);
-      if (lookahead == '|') ADVANCE(42);
+      if (sym_identifier_character_set_2(lookahead)) ADVANCE(84);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(84);
       END_STATE();
     case 84:
       ACCEPT_TOKEN(sym_identifier);
-      if (sym_identifier_character_set_2(lookahead)) ADVANCE(84);
+      if (sym_identifier_character_set_3(lookahead)) ADVANCE(84);
       END_STATE();
     case 85:
       ACCEPT_TOKEN(anon_sym_AT);
@@ -3138,7 +3665,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 102:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
-      if (lookahead == '\'') ADVANCE(21);
+      if (lookahead == '\'') ADVANCE(20);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(aux_sym_simple_bytes_lit_token1);
@@ -3168,7 +3695,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 106:
       ACCEPT_TOKEN(anon_sym_POUND_SQUOTE);
-      if (lookahead == '\'') ADVANCE(22);
+      if (lookahead == '\'') ADVANCE(21);
       END_STATE();
     case 107:
       ACCEPT_TOKEN(anon_sym_SQUOTE_POUND);
@@ -3218,10 +3745,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'O' ||
           lookahead == 'o') ADVANCE(41);
       if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(34);
+          lookahead == 'x') ADVANCE(33);
       if (lookahead == '_') ADVANCE(47);
       if (lookahead == '8' ||
-          lookahead == '9') ADVANCE(31);
+          lookahead == '9') ADVANCE(30);
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(120);
       END_STATE();
     case 119:
@@ -3244,7 +3771,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == 'e') ADVANCE(43);
       if (lookahead == '_') ADVANCE(47);
       if (lookahead == '8' ||
-          lookahead == '9') ADVANCE(31);
+          lookahead == '9') ADVANCE(30);
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(120);
       END_STATE();
     case 121:
@@ -3274,7 +3801,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym_float_lit);
-      if (lookahead == '.') ADVANCE(36);
+      if (lookahead == '.') ADVANCE(35);
       if (lookahead == 'E' ||
           lookahead == 'e') ADVANCE(43);
       if (lookahead == 'G' ||
@@ -3287,7 +3814,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym_float_lit);
-      if (lookahead == '.') ADVANCE(36);
+      if (lookahead == '.') ADVANCE(35);
       if (lookahead == 'E' ||
           lookahead == 'e') ADVANCE(43);
       if (lookahead == 'G' ||
@@ -3452,360 +3979,364 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (lookahead == 'a') ADVANCE(1);
-      if (lookahead == 'b') ADVANCE(2);
-      if (lookahead == 'c') ADVANCE(3);
-      if (lookahead == 'd') ADVANCE(4);
-      if (lookahead == 'f') ADVANCE(5);
-      if (lookahead == 'i') ADVANCE(6);
-      if (lookahead == 'l') ADVANCE(7);
-      if (lookahead == 'm') ADVANCE(8);
-      if (lookahead == 'n') ADVANCE(9);
-      if (lookahead == 'o') ADVANCE(10);
-      if (lookahead == 'p') ADVANCE(11);
-      if (lookahead == 'q') ADVANCE(12);
-      if (lookahead == 'r') ADVANCE(13);
-      if (lookahead == 's') ADVANCE(14);
-      if (lookahead == 't') ADVANCE(15);
-      if (lookahead == 'u') ADVANCE(16);
+      if (lookahead == '_') ADVANCE(1);
+      if (lookahead == 'a') ADVANCE(2);
+      if (lookahead == 'b') ADVANCE(3);
+      if (lookahead == 'c') ADVANCE(4);
+      if (lookahead == 'd') ADVANCE(5);
+      if (lookahead == 'f') ADVANCE(6);
+      if (lookahead == 'i') ADVANCE(7);
+      if (lookahead == 'l') ADVANCE(8);
+      if (lookahead == 'm') ADVANCE(9);
+      if (lookahead == 'n') ADVANCE(10);
+      if (lookahead == 'o') ADVANCE(11);
+      if (lookahead == 'p') ADVANCE(12);
+      if (lookahead == 'q') ADVANCE(13);
+      if (lookahead == 'r') ADVANCE(14);
+      if (lookahead == 's') ADVANCE(15);
+      if (lookahead == 't') ADVANCE(16);
+      if (lookahead == 'u') ADVANCE(17);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
       END_STATE();
     case 1:
-      if (lookahead == 'n') ADVANCE(17);
+      ACCEPT_TOKEN(anon_sym__);
       END_STATE();
     case 2:
-      if (lookahead == 'o') ADVANCE(18);
-      if (lookahead == 'y') ADVANCE(19);
+      if (lookahead == 'n') ADVANCE(18);
       END_STATE();
     case 3:
-      if (lookahead == 'l') ADVANCE(20);
+      if (lookahead == 'o') ADVANCE(19);
+      if (lookahead == 'y') ADVANCE(20);
       END_STATE();
     case 4:
-      if (lookahead == 'i') ADVANCE(21);
+      if (lookahead == 'l') ADVANCE(21);
       END_STATE();
     case 5:
-      if (lookahead == 'a') ADVANCE(22);
-      if (lookahead == 'l') ADVANCE(23);
-      if (lookahead == 'o') ADVANCE(24);
+      if (lookahead == 'i') ADVANCE(22);
       END_STATE();
     case 6:
-      if (lookahead == 'f') ADVANCE(25);
-      if (lookahead == 'm') ADVANCE(26);
-      if (lookahead == 'n') ADVANCE(27);
+      if (lookahead == 'a') ADVANCE(23);
+      if (lookahead == 'l') ADVANCE(24);
+      if (lookahead == 'o') ADVANCE(25);
       END_STATE();
     case 7:
-      if (lookahead == 'e') ADVANCE(28);
+      if (lookahead == 'f') ADVANCE(26);
+      if (lookahead == 'm') ADVANCE(27);
+      if (lookahead == 'n') ADVANCE(28);
       END_STATE();
     case 8:
-      if (lookahead == 'o') ADVANCE(29);
+      if (lookahead == 'e') ADVANCE(29);
       END_STATE();
     case 9:
-      if (lookahead == 'u') ADVANCE(30);
+      if (lookahead == 'o') ADVANCE(30);
       END_STATE();
     case 10:
-      if (lookahead == 'r') ADVANCE(31);
+      if (lookahead == 'u') ADVANCE(31);
       END_STATE();
     case 11:
-      if (lookahead == 'a') ADVANCE(32);
+      if (lookahead == 'r') ADVANCE(32);
       END_STATE();
     case 12:
-      if (lookahead == 'u') ADVANCE(33);
+      if (lookahead == 'a') ADVANCE(33);
       END_STATE();
     case 13:
-      if (lookahead == 'e') ADVANCE(34);
+      if (lookahead == 'u') ADVANCE(34);
       END_STATE();
     case 14:
-      if (lookahead == 't') ADVANCE(35);
+      if (lookahead == 'e') ADVANCE(35);
       END_STATE();
     case 15:
-      if (lookahead == 'r') ADVANCE(36);
+      if (lookahead == 't') ADVANCE(36);
       END_STATE();
     case 16:
-      if (lookahead == 'i') ADVANCE(37);
+      if (lookahead == 'r') ADVANCE(37);
       END_STATE();
     case 17:
-      if (lookahead == 'd') ADVANCE(38);
+      if (lookahead == 'i') ADVANCE(38);
       END_STATE();
     case 18:
-      if (lookahead == 'o') ADVANCE(39);
+      if (lookahead == 'd') ADVANCE(39);
       END_STATE();
     case 19:
-      if (lookahead == 't') ADVANCE(40);
+      if (lookahead == 'o') ADVANCE(40);
       END_STATE();
     case 20:
-      if (lookahead == 'o') ADVANCE(41);
+      if (lookahead == 't') ADVANCE(41);
       END_STATE();
     case 21:
-      if (lookahead == 'v') ADVANCE(42);
+      if (lookahead == 'o') ADVANCE(42);
       END_STATE();
     case 22:
-      if (lookahead == 'l') ADVANCE(43);
+      if (lookahead == 'v') ADVANCE(43);
       END_STATE();
     case 23:
-      if (lookahead == 'o') ADVANCE(44);
+      if (lookahead == 'l') ADVANCE(44);
       END_STATE();
     case 24:
-      if (lookahead == 'r') ADVANCE(45);
+      if (lookahead == 'o') ADVANCE(45);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(anon_sym_if);
+      if (lookahead == 'r') ADVANCE(46);
       END_STATE();
     case 26:
-      if (lookahead == 'p') ADVANCE(46);
+      ACCEPT_TOKEN(anon_sym_if);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(anon_sym_in);
-      if (lookahead == 't') ADVANCE(47);
+      if (lookahead == 'p') ADVANCE(47);
       END_STATE();
     case 28:
-      if (lookahead == 'n') ADVANCE(48);
-      if (lookahead == 't') ADVANCE(49);
+      ACCEPT_TOKEN(anon_sym_in);
+      if (lookahead == 't') ADVANCE(48);
       END_STATE();
     case 29:
-      if (lookahead == 'd') ADVANCE(50);
+      if (lookahead == 'n') ADVANCE(49);
+      if (lookahead == 't') ADVANCE(50);
       END_STATE();
     case 30:
-      if (lookahead == 'l') ADVANCE(51);
-      if (lookahead == 'm') ADVANCE(52);
+      if (lookahead == 'd') ADVANCE(51);
       END_STATE();
     case 31:
-      ACCEPT_TOKEN(anon_sym_or);
+      if (lookahead == 'l') ADVANCE(52);
+      if (lookahead == 'm') ADVANCE(53);
       END_STATE();
     case 32:
-      if (lookahead == 'c') ADVANCE(53);
+      ACCEPT_TOKEN(anon_sym_or);
       END_STATE();
     case 33:
-      if (lookahead == 'o') ADVANCE(54);
+      if (lookahead == 'c') ADVANCE(54);
       END_STATE();
     case 34:
-      if (lookahead == 'm') ADVANCE(55);
+      if (lookahead == 'o') ADVANCE(55);
       END_STATE();
     case 35:
-      if (lookahead == 'r') ADVANCE(56);
+      if (lookahead == 'm') ADVANCE(56);
       END_STATE();
     case 36:
-      if (lookahead == 'u') ADVANCE(57);
+      if (lookahead == 'r') ADVANCE(57);
       END_STATE();
     case 37:
-      if (lookahead == 'n') ADVANCE(58);
+      if (lookahead == 'u') ADVANCE(58);
       END_STATE();
     case 38:
-      ACCEPT_TOKEN(anon_sym_and);
+      if (lookahead == 'n') ADVANCE(59);
       END_STATE();
     case 39:
-      if (lookahead == 'l') ADVANCE(59);
+      ACCEPT_TOKEN(anon_sym_and);
       END_STATE();
     case 40:
-      if (lookahead == 'e') ADVANCE(60);
+      if (lookahead == 'l') ADVANCE(60);
       END_STATE();
     case 41:
-      if (lookahead == 's') ADVANCE(61);
+      if (lookahead == 'e') ADVANCE(61);
       END_STATE();
     case 42:
-      ACCEPT_TOKEN(anon_sym_div);
-      END_STATE();
-    case 43:
       if (lookahead == 's') ADVANCE(62);
       END_STATE();
+    case 43:
+      ACCEPT_TOKEN(anon_sym_div);
+      END_STATE();
     case 44:
-      if (lookahead == 'a') ADVANCE(63);
+      if (lookahead == 's') ADVANCE(63);
       END_STATE();
     case 45:
-      ACCEPT_TOKEN(anon_sym_for);
+      if (lookahead == 'a') ADVANCE(64);
       END_STATE();
     case 46:
-      if (lookahead == 'o') ADVANCE(64);
+      ACCEPT_TOKEN(anon_sym_for);
       END_STATE();
     case 47:
-      ACCEPT_TOKEN(anon_sym_int);
-      if (lookahead == '1') ADVANCE(65);
-      if (lookahead == '3') ADVANCE(66);
-      if (lookahead == '6') ADVANCE(67);
-      if (lookahead == '8') ADVANCE(68);
+      if (lookahead == 'o') ADVANCE(65);
       END_STATE();
     case 48:
-      ACCEPT_TOKEN(anon_sym_len);
+      ACCEPT_TOKEN(anon_sym_int);
+      if (lookahead == '1') ADVANCE(66);
+      if (lookahead == '3') ADVANCE(67);
+      if (lookahead == '6') ADVANCE(68);
+      if (lookahead == '8') ADVANCE(69);
       END_STATE();
     case 49:
-      ACCEPT_TOKEN(anon_sym_let);
+      ACCEPT_TOKEN(anon_sym_len);
       END_STATE();
     case 50:
-      ACCEPT_TOKEN(anon_sym_mod);
+      ACCEPT_TOKEN(anon_sym_let);
       END_STATE();
     case 51:
-      if (lookahead == 'l') ADVANCE(69);
+      ACCEPT_TOKEN(anon_sym_mod);
       END_STATE();
     case 52:
-      if (lookahead == 'b') ADVANCE(70);
+      if (lookahead == 'l') ADVANCE(70);
       END_STATE();
     case 53:
-      if (lookahead == 'k') ADVANCE(71);
+      if (lookahead == 'b') ADVANCE(71);
       END_STATE();
     case 54:
-      ACCEPT_TOKEN(anon_sym_quo);
+      if (lookahead == 'k') ADVANCE(72);
       END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_rem);
+      ACCEPT_TOKEN(anon_sym_quo);
       END_STATE();
     case 56:
-      if (lookahead == 'i') ADVANCE(72);
+      ACCEPT_TOKEN(anon_sym_rem);
       END_STATE();
     case 57:
-      if (lookahead == 'e') ADVANCE(73);
+      if (lookahead == 'i') ADVANCE(73);
       END_STATE();
     case 58:
-      if (lookahead == 't') ADVANCE(74);
+      if (lookahead == 'e') ADVANCE(74);
       END_STATE();
     case 59:
-      ACCEPT_TOKEN(sym_bool_type);
+      if (lookahead == 't') ADVANCE(75);
       END_STATE();
     case 60:
-      if (lookahead == 's') ADVANCE(75);
+      ACCEPT_TOKEN(sym_bool_type);
       END_STATE();
     case 61:
-      if (lookahead == 'e') ADVANCE(76);
+      if (lookahead == 's') ADVANCE(76);
       END_STATE();
     case 62:
       if (lookahead == 'e') ADVANCE(77);
       END_STATE();
     case 63:
-      if (lookahead == 't') ADVANCE(78);
+      if (lookahead == 'e') ADVANCE(78);
       END_STATE();
     case 64:
-      if (lookahead == 'r') ADVANCE(79);
+      if (lookahead == 't') ADVANCE(79);
       END_STATE();
     case 65:
-      if (lookahead == '2') ADVANCE(80);
-      if (lookahead == '6') ADVANCE(81);
+      if (lookahead == 'r') ADVANCE(80);
       END_STATE();
     case 66:
-      if (lookahead == '2') ADVANCE(82);
+      if (lookahead == '2') ADVANCE(81);
+      if (lookahead == '6') ADVANCE(82);
       END_STATE();
     case 67:
-      if (lookahead == '4') ADVANCE(83);
+      if (lookahead == '2') ADVANCE(83);
       END_STATE();
     case 68:
-      ACCEPT_TOKEN(anon_sym_int8);
+      if (lookahead == '4') ADVANCE(84);
       END_STATE();
     case 69:
-      ACCEPT_TOKEN(sym_null);
+      ACCEPT_TOKEN(anon_sym_int8);
       END_STATE();
     case 70:
-      if (lookahead == 'e') ADVANCE(84);
+      ACCEPT_TOKEN(sym_null);
       END_STATE();
     case 71:
-      if (lookahead == 'a') ADVANCE(85);
+      if (lookahead == 'e') ADVANCE(85);
       END_STATE();
     case 72:
-      if (lookahead == 'n') ADVANCE(86);
+      if (lookahead == 'a') ADVANCE(86);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(sym_true);
+      if (lookahead == 'n') ADVANCE(87);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(anon_sym_uint);
-      if (lookahead == '1') ADVANCE(87);
-      if (lookahead == '3') ADVANCE(88);
-      if (lookahead == '6') ADVANCE(89);
-      if (lookahead == '8') ADVANCE(90);
+      ACCEPT_TOKEN(sym_true);
       END_STATE();
     case 75:
-      ACCEPT_TOKEN(sym_bytes_type);
+      ACCEPT_TOKEN(anon_sym_uint);
+      if (lookahead == '1') ADVANCE(88);
+      if (lookahead == '3') ADVANCE(89);
+      if (lookahead == '6') ADVANCE(90);
+      if (lookahead == '8') ADVANCE(91);
       END_STATE();
     case 76:
-      ACCEPT_TOKEN(anon_sym_close);
+      ACCEPT_TOKEN(sym_bytes_type);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym_false);
+      ACCEPT_TOKEN(anon_sym_close);
       END_STATE();
     case 78:
-      ACCEPT_TOKEN(anon_sym_float);
-      if (lookahead == '3') ADVANCE(91);
-      if (lookahead == '6') ADVANCE(92);
+      ACCEPT_TOKEN(sym_false);
       END_STATE();
     case 79:
-      if (lookahead == 't') ADVANCE(93);
+      ACCEPT_TOKEN(anon_sym_float);
+      if (lookahead == '3') ADVANCE(92);
+      if (lookahead == '6') ADVANCE(93);
       END_STATE();
     case 80:
-      if (lookahead == '8') ADVANCE(94);
+      if (lookahead == 't') ADVANCE(94);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(anon_sym_int16);
+      if (lookahead == '8') ADVANCE(95);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(anon_sym_int32);
+      ACCEPT_TOKEN(anon_sym_int16);
       END_STATE();
     case 83:
-      ACCEPT_TOKEN(anon_sym_int64);
+      ACCEPT_TOKEN(anon_sym_int32);
       END_STATE();
     case 84:
-      if (lookahead == 'r') ADVANCE(95);
+      ACCEPT_TOKEN(anon_sym_int64);
       END_STATE();
     case 85:
-      if (lookahead == 'g') ADVANCE(96);
+      if (lookahead == 'r') ADVANCE(96);
       END_STATE();
     case 86:
       if (lookahead == 'g') ADVANCE(97);
       END_STATE();
     case 87:
-      if (lookahead == '2') ADVANCE(98);
-      if (lookahead == '6') ADVANCE(99);
+      if (lookahead == 'g') ADVANCE(98);
       END_STATE();
     case 88:
-      if (lookahead == '2') ADVANCE(100);
+      if (lookahead == '2') ADVANCE(99);
+      if (lookahead == '6') ADVANCE(100);
       END_STATE();
     case 89:
-      if (lookahead == '4') ADVANCE(101);
+      if (lookahead == '2') ADVANCE(101);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(anon_sym_uint8);
+      if (lookahead == '4') ADVANCE(102);
       END_STATE();
     case 91:
-      if (lookahead == '2') ADVANCE(102);
+      ACCEPT_TOKEN(anon_sym_uint8);
       END_STATE();
     case 92:
-      if (lookahead == '4') ADVANCE(103);
+      if (lookahead == '2') ADVANCE(103);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(anon_sym_import);
+      if (lookahead == '4') ADVANCE(104);
       END_STATE();
     case 94:
-      ACCEPT_TOKEN(anon_sym_int128);
+      ACCEPT_TOKEN(anon_sym_import);
       END_STATE();
     case 95:
-      ACCEPT_TOKEN(sym_number_type);
+      ACCEPT_TOKEN(anon_sym_int128);
       END_STATE();
     case 96:
-      if (lookahead == 'e') ADVANCE(104);
+      ACCEPT_TOKEN(sym_number_type);
       END_STATE();
     case 97:
-      ACCEPT_TOKEN(sym_string_type);
+      if (lookahead == 'e') ADVANCE(105);
       END_STATE();
     case 98:
-      if (lookahead == '8') ADVANCE(105);
+      ACCEPT_TOKEN(sym_string_type);
       END_STATE();
     case 99:
-      ACCEPT_TOKEN(anon_sym_uint16);
+      if (lookahead == '8') ADVANCE(106);
       END_STATE();
     case 100:
-      ACCEPT_TOKEN(anon_sym_uint32);
+      ACCEPT_TOKEN(anon_sym_uint16);
       END_STATE();
     case 101:
-      ACCEPT_TOKEN(anon_sym_uint64);
+      ACCEPT_TOKEN(anon_sym_uint32);
       END_STATE();
     case 102:
-      ACCEPT_TOKEN(anon_sym_float32);
+      ACCEPT_TOKEN(anon_sym_uint64);
       END_STATE();
     case 103:
-      ACCEPT_TOKEN(anon_sym_float64);
+      ACCEPT_TOKEN(anon_sym_float32);
       END_STATE();
     case 104:
-      ACCEPT_TOKEN(anon_sym_package);
+      ACCEPT_TOKEN(anon_sym_float64);
       END_STATE();
     case 105:
+      ACCEPT_TOKEN(anon_sym_package);
+      END_STATE();
+    case 106:
       ACCEPT_TOKEN(anon_sym_uint128);
       END_STATE();
     default:
@@ -4049,10 +4580,10 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [232] = {.lex_state = 6},
   [233] = {.lex_state = 6},
   [234] = {.lex_state = 6},
-  [235] = {.lex_state = 0},
-  [236] = {.lex_state = 0},
-  [237] = {.lex_state = 0},
-  [238] = {.lex_state = 0},
+  [235] = {.lex_state = 6},
+  [236] = {.lex_state = 6},
+  [237] = {.lex_state = 6},
+  [238] = {.lex_state = 6},
   [239] = {.lex_state = 0},
   [240] = {.lex_state = 0},
   [241] = {.lex_state = 0},
@@ -4069,14 +4600,14 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [252] = {.lex_state = 0},
   [253] = {.lex_state = 0},
   [254] = {.lex_state = 6},
-  [255] = {.lex_state = 0},
-  [256] = {.lex_state = 0},
-  [257] = {.lex_state = 0},
-  [258] = {.lex_state = 0},
-  [259] = {.lex_state = 0},
-  [260] = {.lex_state = 0},
-  [261] = {.lex_state = 0},
-  [262] = {.lex_state = 0},
+  [255] = {.lex_state = 6},
+  [256] = {.lex_state = 6},
+  [257] = {.lex_state = 6},
+  [258] = {.lex_state = 6},
+  [259] = {.lex_state = 6},
+  [260] = {.lex_state = 6},
+  [261] = {.lex_state = 6},
+  [262] = {.lex_state = 6},
   [263] = {.lex_state = 4},
   [264] = {.lex_state = 4},
   [265] = {.lex_state = 4},
@@ -4089,7 +4620,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [272] = {.lex_state = 5},
   [273] = {.lex_state = 5},
   [274] = {.lex_state = 5},
-  [275] = {.lex_state = 0},
+  [275] = {.lex_state = 6},
   [276] = {.lex_state = 5},
   [277] = {.lex_state = 5},
   [278] = {.lex_state = 5},
@@ -4106,7 +4637,7 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [289] = {.lex_state = 10, .external_lex_state = 2},
   [290] = {.lex_state = 10, .external_lex_state = 4},
   [291] = {.lex_state = 12, .external_lex_state = 7},
-  [292] = {.lex_state = 0},
+  [292] = {.lex_state = 6},
   [293] = {.lex_state = 10, .external_lex_state = 4},
   [294] = {.lex_state = 0, .external_lex_state = 3},
   [295] = {.lex_state = 12, .external_lex_state = 5},
@@ -4139,58 +4670,58 @@ static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [322] = {.lex_state = 0, .external_lex_state = 3},
   [323] = {.lex_state = 10, .external_lex_state = 4},
   [324] = {.lex_state = 12, .external_lex_state = 7},
-  [325] = {.lex_state = 28},
+  [325] = {.lex_state = 27},
   [326] = {.lex_state = 6},
   [327] = {.lex_state = 0},
-  [328] = {.lex_state = 28},
-  [329] = {.lex_state = 28},
+  [328] = {.lex_state = 27},
+  [329] = {.lex_state = 27},
   [330] = {.lex_state = 0},
   [331] = {.lex_state = 10},
-  [332] = {.lex_state = 28},
+  [332] = {.lex_state = 27},
   [333] = {.lex_state = 10, .external_lex_state = 2},
   [334] = {.lex_state = 12, .external_lex_state = 7},
   [335] = {.lex_state = 10, .external_lex_state = 4},
   [336] = {.lex_state = 0},
-  [337] = {.lex_state = 28},
+  [337] = {.lex_state = 27},
   [338] = {.lex_state = 0},
   [339] = {.lex_state = 0, .external_lex_state = 3},
   [340] = {.lex_state = 12, .external_lex_state = 5},
   [341] = {.lex_state = 0, .external_lex_state = 6},
   [342] = {.lex_state = 6},
   [343] = {.lex_state = 10},
-  [344] = {.lex_state = 6},
+  [344] = {.lex_state = 10},
   [345] = {.lex_state = 0},
   [346] = {.lex_state = 0},
   [347] = {.lex_state = 0},
   [348] = {.lex_state = 0},
   [349] = {.lex_state = 3},
   [350] = {.lex_state = 3},
-  [351] = {.lex_state = 0},
-  [352] = {.lex_state = 0},
+  [351] = {.lex_state = 6},
+  [352] = {.lex_state = 6},
   [353] = {.lex_state = 0},
   [354] = {.lex_state = 3},
   [355] = {.lex_state = 3},
-  [356] = {.lex_state = 0},
+  [356] = {.lex_state = 6},
   [357] = {.lex_state = 0},
-  [358] = {.lex_state = 0},
-  [359] = {.lex_state = 0},
+  [358] = {.lex_state = 6},
+  [359] = {.lex_state = 6},
   [360] = {.lex_state = 0},
   [361] = {.lex_state = 0},
   [362] = {.lex_state = 0},
   [363] = {.lex_state = 0},
-  [364] = {.lex_state = 6},
-  [365] = {.lex_state = 6},
+  [364] = {.lex_state = 10},
+  [365] = {.lex_state = 10},
   [366] = {.lex_state = 0},
   [367] = {.lex_state = 0},
-  [368] = {.lex_state = 0},
+  [368] = {.lex_state = 6},
   [369] = {.lex_state = 0},
   [370] = {.lex_state = 0},
   [371] = {.lex_state = 0},
   [372] = {.lex_state = 0},
   [373] = {.lex_state = 0},
-  [374] = {.lex_state = 0},
+  [374] = {.lex_state = 6},
   [375] = {.lex_state = 0},
-  [376] = {.lex_state = 0},
+  [376] = {.lex_state = 6},
 };
 
 enum {
@@ -23530,20 +24061,20 @@ static const uint16_t ts_small_parse_table[] = {
   [4164] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(1009), 5,
-      anon_sym__,
-      anon_sym_DQUOTE,
-      anon_sym_POUND_DQUOTE,
-      anon_sym_SQUOTE,
-      anon_sym_POUND_SQUOTE,
-    ACTIONS(943), 7,
+    ACTIONS(943), 6,
       anon_sym_RPAREN,
       sym_dot,
-      sym_identifier,
       anon_sym_DQUOTE_DQUOTE_DQUOTE,
       anon_sym_POUND_DQUOTE_DQUOTE_DQUOTE,
       anon_sym_SQUOTE_SQUOTE_SQUOTE,
       anon_sym_POUND_SQUOTE_SQUOTE_SQUOTE,
+    ACTIONS(1009), 6,
+      anon_sym__,
+      sym_identifier,
+      anon_sym_DQUOTE,
+      anon_sym_POUND_DQUOTE,
+      anon_sym_SQUOTE,
+      anon_sym_POUND_SQUOTE,
   [4184] = 8,
     ACTIONS(3), 1,
       sym_comment,
@@ -25420,7 +25951,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [906] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_list_lit_repeat1, 1, .production_id = 2),
   [908] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__list_elem, 5, .production_id = 8),
   [910] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__list_elem, 5, .production_id = 8),
-  [912] = {.entry = {.count = 1, .reusable = true}}, SHIFT(266),
+  [912] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
   [914] = {.entry = {.count = 1, .reusable = true}}, SHIFT(232),
   [916] = {.entry = {.count = 1, .reusable = true}}, SHIFT(243),
   [918] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
@@ -25434,7 +25965,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [934] = {.entry = {.count = 1, .reusable = true}}, SHIFT(312),
   [936] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
   [938] = {.entry = {.count = 1, .reusable = true}}, SHIFT(241),
-  [940] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_import_spec_list_repeat1, 2), SHIFT_REPEAT(266),
+  [940] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_import_spec_list_repeat1, 2), SHIFT_REPEAT(266),
   [943] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_import_spec_list_repeat1, 2),
   [945] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_import_spec_list_repeat1, 2), SHIFT_REPEAT(241),
   [948] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_import_spec_list_repeat1, 2), SHIFT_REPEAT(261),
@@ -25596,7 +26127,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1289] = {.entry = {.count = 1, .reusable = true}}, SHIFT(297),
   [1291] = {.entry = {.count = 1, .reusable = false}}, SHIFT(184),
   [1293] = {.entry = {.count = 1, .reusable = false}}, SHIFT(328),
-  [1295] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [1295] = {.entry = {.count = 1, .reusable = false}}, SHIFT(359),
   [1297] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2), SHIFT_REPEAT(41),
   [1300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2),
   [1302] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_attribute_repeat1, 2),
@@ -25612,7 +26143,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1323] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
   [1325] = {.entry = {.count = 1, .reusable = false}}, SHIFT(180),
   [1327] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [1329] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
+  [1329] = {.entry = {.count = 1, .reusable = false}}, SHIFT(352),
   [1331] = {.entry = {.count = 1, .reusable = true}}, SHIFT(86),
   [1333] = {.entry = {.count = 1, .reusable = true}}, SHIFT(272),
   [1335] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__label_name, 1),

--- a/test/corpus/identifier.txt
+++ b/test/corpus/identifier.txt
@@ -6,11 +6,18 @@ CamelCase: string
 $after: string
 snake_case: string
 some_456_Numbers: string
+#def: string
+_#hiddenDef: string
+#_notSohidden: string
+
 
 ---
 
-(source_file 
- (field (label (identifier)) (value (string_type))) 
- (field (label (identifier)) (value (string_type))) 
- (field (label (identifier)) (value (string_type))) 
+(source_file
+ (field (label (identifier)) (value (string_type)))
+ (field (label (identifier)) (value (string_type)))
+ (field (label (identifier)) (value (string_type)))
+ (field (label (identifier)) (value (string_type)))
+ (field (label (identifier)) (value (string_type)))
+ (field (label (identifier)) (value (string_type)))
  (field (label (identifier)) (value (string_type))))


### PR DESCRIPTION
Per spec: identifier  = [ "#" | "_#" ] letter { letter | unicode_digit }

Where letter includes _ and $.

This patch fixes parsing of identifiers of the form #_xxx.