### PR TITLE
ci: replace broken fuzz action with official tree-sitter/fuzz-action

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,13 +9,9 @@ on:
       - src/scanner.c
 
 jobs:
-  test:
+  fuzz:
     name: Parser fuzzing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: vigoux/tree-sitter-fuzz-action@v1
-        with:
-          language: cue
-          external-scanner: src/scanner.c
-          time: 60
+      - uses: actions/checkout@v4
+      - uses: tree-sitter/fuzz-action@v4


### PR DESCRIPTION
## Summary

- Replace broken `vigoux/tree-sitter-fuzz-action@v1` with the official `tree-sitter/fuzz-action@v4`
- Bump `actions/checkout` from v3 to v4

The `vigoux/tree-sitter-fuzz-action` Docker build fails because upstream tree-sitter reorganized their repo and the `cli/` directory no longer exists. Both `v1` and `v1.1` tags have the same broken Dockerfile.

`tree-sitter/fuzz-action@v4` is maintained by the tree-sitter team and used by all official grammar repos (tree-sitter-go, tree-sitter-rust, tree-sitter-javascript, etc.). It handles library installation, parser generation, dictionary extraction, sanitizer compilation, fuzzer execution, and crash artifact upload on failure.

## Test plan

- [ ] `Parser fuzzing` CI job passes on this PR